### PR TITLE
ThemeEnabledSettingsFlyout and generalizing to ThemeEnableThisElement

### DIFF
--- a/ThemeManagerRt/ThemeEnabledSettingsFlyout.cs
+++ b/ThemeManagerRt/ThemeEnabledSettingsFlyout.cs
@@ -2,9 +2,9 @@
 
 namespace ThemeManagerRt
 {
-    public class ThemeEnabledPage : Page
+    public class ThemeEnabledSettingsFlyout : SettingsFlyout
     {
-        public ThemeEnabledPage()
+        public ThemeEnabledSettingsFlyout()
         {
             this.ThemeEnableThisElement();
         }

--- a/ThemeManagerRt/ThemeExtensions.cs
+++ b/ThemeManagerRt/ThemeExtensions.cs
@@ -7,7 +7,7 @@ namespace ThemeManagerRt
 {
     public static class ThemeExtensions
     {
-        public static void ThemeEnableThisPage(this Page page)
+        public static void ThemeEnableThisElement(this FrameworkElement element)
         {
             var tm = Application.Current.Resources["ThemeManager"];
             if (tm == null)
@@ -21,7 +21,8 @@ namespace ThemeManagerRt
                 Path = new PropertyPath("Theme"),
                 Mode = BindingMode.OneWay
             };
-            page.SetBinding(Page.RequestedThemeProperty, binding);
+
+            element.SetBinding(FrameworkElement.RequestedThemeProperty, binding);
         }
     }
 }

--- a/ThemeManagerRt/ThemeManagerRt.csproj
+++ b/ThemeManagerRt/ThemeManagerRt.csproj
@@ -42,6 +42,7 @@
     <TargetPlatform Include="Windows, Version=8.1" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ThemeEnabledSettingsFlyout.cs" />
     <Compile Include="ThemeEnabledPage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ThemeExtensions.cs" />


### PR DESCRIPTION
Thank you very much for this, I really needed this theme manager, but for my project I also needed to make my own ThemeEnabledSettingsFlyout and I think there would be a better way to do that if I change ThemeEnableThisPage to ThemeEnableThisElement and use FrameworkElement instead, so I can use this code in both ThemeEnabledPage and ThemeEnabledSettingsFlyout.
